### PR TITLE
Update order url

### DIFF
--- a/core/templates/buyerLanding.html
+++ b/core/templates/buyerLanding.html
@@ -14,10 +14,10 @@
       <p class="card-text">{{object.product_description}}</p>
       <div class='row mt-3 mx-0'>
       <p class="card-price my-0">{{btc_price}} BTC ≈ {{usd_price}} USD</p>
-      <button type="submit" id='submitbtn' class="btn ml-auto"><a href="{% url 'core:product_pay_buyer' object.uid%}?crypto=BTC"
+      <button type="submit" id='submitbtn' class="btn ml-auto"><a href="{% url 'core:product_pay_buyer' object.uid order_id%}?crypto=BTC"
         style="text-decoration:none;color:white;">I want this! </a></button>
         {% comment %} <button type="submit" id='submitbtn' class="btn"><a
-        href="{% url 'core:product_pay_buyer' object.uid%}?crypto=BCH" style="text-decoration:none;color:black;">Buy
+        href="{% url 'core:product_pay_buyer' object.uid order_id%}?crypto=BCH" style="text-decoration:none;color:black;">Buy
         in BCH -
         {{bch_price}}</a></button>
       </div>

--- a/core/templates/buyerLanding.html
+++ b/core/templates/buyerLanding.html
@@ -14,10 +14,10 @@
       <p class="card-text">{{object.product_description}}</p>
       <div class='row mt-3 mx-0'>
       <p class="card-price my-0">{{btc_price}} BTC ≈ {{usd_price}} USD</p>
-      <button type="submit" id='submitbtn' class="btn ml-auto"><a href="{% url 'core:product_pay_buyer' object.uid order_id%}?crypto=BTC"
+      <button type="submit" id='submitbtn' class="btn ml-auto"><a href="{% url 'core:product_pay_buyer' order_id%}?crypto=BTC"
         style="text-decoration:none;color:white;">I want this! </a></button>
         {% comment %} <button type="submit" id='submitbtn' class="btn"><a
-        href="{% url 'core:product_pay_buyer' object.uid order_id%}?crypto=BCH" style="text-decoration:none;color:black;">Buy
+        href="{% url 'core:product_pay_buyer' order_id%}?crypto=BCH" style="text-decoration:none;color:black;">Buy
         in BCH -
         {{bch_price}}</a></button>
       </div>

--- a/core/urls.py
+++ b/core/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
         name="product_info_buyer",
     ),
     re_path(
-        r"^(?P<uid>[0-9a-f-]+)&order_id=(?P<order_id>\w+)/$",
+        r"^checkout/(?P<order_id>\w+)$",
         views.IntializePayment.as_view(),
         name="product_pay_buyer",
     ),

--- a/core/urls.py
+++ b/core/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
         name="product_info_buyer",
     ),
     re_path(
-        r"^(?P<uid>[0-9a-f-]+)/pay/$",
+        r"^(?P<uid>[0-9a-f-]+)&order_id=(?P<order_id>\w+)/$",
         views.IntializePayment.as_view(),
         name="product_pay_buyer",
     ),

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,7 +1,6 @@
 import zipfile
 import io
 import os
-from django.shortcuts import get_object_or_404
 from django.core.mail import EmailMultiAlternatives
 from django.template import loader
 from django.contrib.sites.shortcuts import get_current_site
@@ -85,9 +84,6 @@ def check_session_validity(request, product):
 
 def create_payment_helper(request, product, crypto, usd_price):
     address, expected_value = create_payment(product, crypto)
-    payment = Payment.objects.create(
-        address=address, expected_value=expected_value, crypto=crypto, product=product, usd_price=usd_price
-    )
     usd_price = exchanged_rate_to_usd(expected_value, "BTC", "USD")
     payment = Payment.objects.create(
         address=address, expected_value=expected_value, crypto=crypto, product=product, usd_price=usd_price

--- a/core/utils.py
+++ b/core/utils.py
@@ -89,4 +89,4 @@ def create_payment_helper(request, product, crypto, usd_price):
         address=address, expected_value=expected_value, crypto=crypto, product=product, usd_price=usd_price
     )
     request.session["last_order"] = datetime.now().timestamp()
-    return payment, address, expected_value, usd_price
+    return payment

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,6 +1,7 @@
 import zipfile
 import io
 import os
+from django.shortcuts import get_object_or_404
 from django.core.mail import EmailMultiAlternatives
 from django.template import loader
 from django.contrib.sites.shortcuts import get_current_site
@@ -84,6 +85,9 @@ def check_session_validity(request, product):
 
 def create_payment_helper(request, product, crypto, usd_price):
     address, expected_value = create_payment(product, crypto)
+    payment = Payment.objects.create(
+        address=address, expected_value=expected_value, crypto=crypto, product=product, usd_price=usd_price
+    )
     usd_price = exchanged_rate_to_usd(expected_value, "BTC", "USD")
     payment = Payment.objects.create(
         address=address, expected_value=expected_value, crypto=crypto, product=product, usd_price=usd_price

--- a/core/views.py
+++ b/core/views.py
@@ -13,8 +13,6 @@ from django.utils.decorators import method_decorator
 from .utils import zipFiles, email_helper, create_payment_helper, check_session_validity
 from django.db.models import Prefetch
 from datetime import datetime, timedelta
-import uuid
-from uuid import UUID
 
 # Create your views here.
 
@@ -170,10 +168,8 @@ class IntializePayment(generic.View):
             expected_value = float(payment.expected_value)
             usd_price = float(payment.usd_price)
             request.session["last_order"] = datetime.now().timestamp()
-            # check_session_validity(request, product)
         except (ValueError, Http404, KeyError) as e:  # invalid session
-            print('hello')
-            # payment, address, expected_value, usd_price = create_payment_helper(request, product, crypto, usd_price)
+            return HttpResponse(e.response.text)
         except requests.exceptions.RequestException as e:  # Exception at blockonomics api
             return HttpResponse(e.response.text)
         except Exception as e:

--- a/core/views.py
+++ b/core/views.py
@@ -144,7 +144,7 @@ class ProductPublicView(HitCountDetailView):
         context["bits"] = exchanged_rate(self.object.price, "BTC", self.object.currency)
         context["btc_price"] = context["bits"]/pow(10, 8)
         product = get_object_or_404(Product, uid=self.kwargs.get("uid"))
-        payment, address, expected_value, usd_price = create_payment_helper(self.request, product, "BTC", self.object.price)
+        payment = create_payment_helper(self.request, product, "BTC", self.object.price)
         context["order_id"] = payment.order_id
         # context["bch_price"]=str(exchanged_rate(self.object.price,"BTC",self.object.currency))[:6]
         return context
@@ -155,7 +155,7 @@ class IntializePayment(generic.View):
 
     @method_decorator(never_cache)
     def get(self, request, *args, **kwargs):
-        product = get_object_or_404(Product, uid=kwargs["uid"])
+        # product = get_object_or_404(Product, uid=kwargs["uid"])
         crypto = request.GET.get("crypto", None)
         # if crypto not in ["BTC","BCH"]:
         if crypto not in ["BTC"]:
@@ -164,6 +164,7 @@ class IntializePayment(generic.View):
         address, expected_value, payment, usd_price = None, None, None, None
         try:
             payment = get_object_or_404(Payment, order_id=kwargs["order_id"])
+            product = payment.product
             address = payment.address
             expected_value = float(payment.expected_value)
             usd_price = float(payment.usd_price)


### PR DESCRIPTION
In regards to Issue #5:

## Order URL / Payment Screen
The previous way of organizing the order/payment page was based around products and sessions. This means that each order was bound to one user and his browser session. There was no way of sharing a URL to someone, so they would get up the same order.

- [X] Add payment_id/order_id to the URL
- [X] Track orders based on payment_id/order_id instead of a user's browser session
- [x] Remove the product portion of the URL to simplify, since the product can be found through the `payment` object. 
